### PR TITLE
Handle additional unexpected properties

### DIFF
--- a/src/Suivi/ContextData.php
+++ b/src/Suivi/ContextData.php
@@ -23,6 +23,12 @@ class ContextData
 
     /** @var array */
     protected $removal_point;
+    
+    /** @var string **/
+    protected $locomotion_mode;
+    
+    /** @var string **/
+    protected $energy_class_code;
 
     /** @var string */
     protected $origin_country;
@@ -68,6 +74,38 @@ class ContextData
         $this->removal_point = $removal_oint;
     }
 
+    /**
+     * @return string
+     */
+    public function getLocomotionMode()
+    {
+        return $this->locomotion_mode;
+    }
+    
+    /**
+     * @param string
+     */
+    public function setLocomotionMode($locomotion_mode)
+    {
+        $this->locomotion_mode = $locomotion_mode;
+    }
+    
+    /**
+     * @return string
+     */
+    public function getEnergyClassCode()
+    {
+        return $this->energy_class_code;
+    }
+    
+    /**
+     * @param string
+     */
+    public function setEnergyClassCode($energy_class_code)
+    {
+        $this->energy_class_code = $energy_class_code;
+    }
+    
     /**
      * @return string
      */

--- a/src/Suivi/Response.php
+++ b/src/Suivi/Response.php
@@ -37,6 +37,9 @@ class Response
 
     /** @var string */
     protected $return_message;
+    
+    /** @var string */
+    protected $technical_message;
 
     /** @var string */
     protected $id_ship;
@@ -131,6 +134,14 @@ class Response
     {
         return $this->return_message;
     }
+    
+    /**
+     * @return string
+     */
+    public function getTechnicalMessage()
+    {
+        return $this->technical_message;
+    }
 
     /**
      * @param $return_message
@@ -139,6 +150,14 @@ class Response
     {
         $this->return_message = $return_message;
     }
+    
+    /**
+     * @param string
+     */
+    /*public function setTechnicalMessage($technical_message)
+    {
+        $this->technical_message = $technical_message;
+    }*/
 
     /**
      * @return string

--- a/src/Suivi/Shipment.php
+++ b/src/Suivi/Shipment.php
@@ -279,7 +279,7 @@ class Shipment
     {
         $context_data = new ContextData();
         foreach ($data as $parameter => $value) {
-            $context_data->{'set'.$parameter}($value);
+            $context_data->{'set'.ucfirst($parameter)}($value);
         }
 
         $this->context_data = $context_data;


### PR DESCRIPTION
Even if these properties should probably not be exposed by the API it seems better to avoid fatal errors for unknown `set()` methods.

reponse.technical_message
contextData.locomotion_mode
contextData.energy_class_code